### PR TITLE
Fix Returning Block of Sticks player selection

### DIFF
--- a/src/main/java/lumien/randomthings/block/BlockBlockOfSticks.java
+++ b/src/main/java/lumien/randomthings/block/BlockBlockOfSticks.java
@@ -109,7 +109,7 @@ public class BlockBlockOfSticks extends BlockBase
 						}
 					});
 
-					EntityPlayer closes = playerList.get(playerList.size() - 1);
+					EntityPlayer closes = playerList.get(0);
 
 					if (!closes.capabilities.isCreativeMode)
 					{


### PR DESCRIPTION
Changed the RBoS code to take the first player from the sorted list instead of the last player, since the list is sorted closest to furthest.